### PR TITLE
Update publications

### DIFF
--- a/content/page/publications.md
+++ b/content/page/publications.md
@@ -4,13 +4,18 @@ subtitle: Talks und Präsentationen
 comments: true
 ---
 
-* [Going mouseless](https://jug-in.github.io/jug-in.talks/going.mouseless.html)
+* [Going (almost) mouseless](https://jug-in.github.io/jug-in.talks/going.mouseless.html)
 * [Caching](https://jug-in.github.io/jug-in.talks/caching.html)
 * [java.time (JSR 310)](https://jug-in.github.io/jug-in.talks/java.time.html)
 * [GitOps (Java aktuell 06/2019)](https://github.com/jug-in/publikationen/raw/master/06_2019-java_aktuell-bernd_stuebinger_florian_heubeck-gitops_mit_helm_und_kubernetes.pdf)
-* [How to quit VIM](https://github.com/jug-in/publikationen/raw/master/jug-in-vim-talk.pdf)
+* [How to quit vim?](https://github.com/jug-in/publikationen/raw/master/jug-in-vim-talk.pdf)
 * [RETIT: Open Source APM](https://www.retit.de/wp-content/uploads/2019/08/20190806_Open_Source_APM.pdf)
 * [INNOQ: MVC 1.0 und Eclipse Krazo](https://www.innoq.com/de/talks/2019/09/webanwendungen-mvc-krazo-jug-in/)
 * [INNOQ: Das eierlegende Truffleschwein](https://www.innoq.com/de/talks/2019/09/das-eierlegende-truffleschwein-ingolstadt/)
 * [JMH Benchmark](https://jug-in.github.io/jug-in.talks/jmh.html)
 * [JDK 12](https://jug-in.github.io/jug-in.talks/jdk12.html)
+* [JDK 15](https://jug-in.github.io/jug-in.talks/jdk15.html)
+* [JDK 16](https://jug-in.github.io/jug-in.talks/jdk16.html)
+* [Software-Esoterik-1](https://jug-in.github.io/jug-in.talks/software-esoterik-1.html)
+* [Red Hat: Kafka Special](http://www.jsch.cz/jugingolstadt)
+* [Red Hat: Modern Reactive Java](https://github.com/jug-in/jug-in.talks/raw/master/3rd/ingolstadt-jug-jan2021.pdf)


### PR DESCRIPTION
Eher mal zur Diskussion, wie wir mit der Seite weitermachen wollen.

Die Auflistung wirkt ein bißchen... unmotiviert. Manche der Slides sind von uns, manche nicht; manche sind aus Talks, die auch unter Talks nochmal gelistet sind; zu manchen Talks gibt es keine Präsentationen und insgesamt ist das mit manuelle Aktualisierung nicht sehr praktikabel (qed).

Aber zumindest ist die Liste jetzt wieder ein bißchen aktueller.