### PR TITLE
fix(content): change header title Posts to Talks

### DIFF
--- a/content/post/_index.md
+++ b/content/post/_index.md
@@ -1,0 +1,3 @@
+---
+title: Talks
+---


### PR DESCRIPTION
Change the default post content header title to align it with the
one in navigation bar.
